### PR TITLE
grammar, in line about repo maintainer setup

### DIFF
--- a/docs/team-onboarding.md
+++ b/docs/team-onboarding.md
@@ -2,7 +2,7 @@
 All teams go thru the following steps to get onboarded
 
 - [ ] Team members congregate in the challenge channel (#c-challenge-name) 
-- [ ] Teams elect a repo "maintainer" who has a github user and will be the point-of-contact with a tech volunteers.
+- [ ] Teams elect a repo "maintainer" who has a github user account and will be the point-of-contact with tech volunteers.
 - [ ] Sign-up on the [onboarding form](https://forms.gle/aYMg9M2vFdFTgAhH6)
 - [ ] Team maintainer visits #tech-mentors or #tech-repo-wranglers channel to announce they have formed! 
 - [ ] A Tech Mentor or Repo Wrangler creates a repo in the [this organization](https://github.com/Hack4Eugene) using the [short-challenge-name]-[team-name]-[year] format and adds a readme.md and an MIT license to the repo.


### PR DESCRIPTION
- changed from team tech liasons needing a github user to needing a github user account.
- simplified from "and will be" to "to be" (the point of contact).
- removed singular article before plural noun (was: "a volunteers").